### PR TITLE
Modify getAnnotated to return all classes that have any class, method, o...

### DIFF
--- a/silver/src/main/java/org/silver/SilverWorker.java
+++ b/silver/src/main/java/org/silver/SilverWorker.java
@@ -17,6 +17,7 @@ package org.silver;
 
 import com.sun.codemodel.*;
 import org.androidtransfuse.adapter.ASTAnnotation;
+import org.androidtransfuse.adapter.ASTField;
 import org.androidtransfuse.adapter.ASTMethod;
 import org.androidtransfuse.adapter.ASTType;
 import org.androidtransfuse.adapter.element.ASTElementFactory;
@@ -108,7 +109,19 @@ public class SilverWorker extends AbstractCompletionTransactionWorker<Provider<A
             matcherConjunction.add(new Matcher<ASTType>() {
                 @Override
                 public boolean matches(ASTType astType) {
-                    for (ASTAnnotation astAnnotation : astType.getAnnotations()) {
+                    final ArrayList<ASTAnnotation> annotations = new ArrayList<ASTAnnotation>();
+
+                    for( ASTMethod astMethod : astType.getMethods()) {
+                        annotations.addAll(astMethod.getAnnotations());
+                    }
+
+                    for( ASTField astField : astType.getFields()) {
+                        annotations.addAll(astField.getAnnotations());
+                    }
+
+                    annotations.addAll(astType.getAnnotations());
+
+                    for (ASTAnnotation astAnnotation : annotations) {
                         if(astAnnotation.getASTType().equals(annotatedBy)){
                             return true;
                         }

--- a/silver/src/main/java/org/silver/SilverWorker.java
+++ b/silver/src/main/java/org/silver/SilverWorker.java
@@ -16,10 +16,7 @@
 package org.silver;
 
 import com.sun.codemodel.*;
-import org.androidtransfuse.adapter.ASTAnnotation;
-import org.androidtransfuse.adapter.ASTField;
-import org.androidtransfuse.adapter.ASTMethod;
-import org.androidtransfuse.adapter.ASTType;
+import org.androidtransfuse.adapter.*;
 import org.androidtransfuse.adapter.element.ASTElementFactory;
 import org.androidtransfuse.gen.ClassGenerationUtil;
 import org.androidtransfuse.gen.ClassNamer;
@@ -113,6 +110,10 @@ public class SilverWorker extends AbstractCompletionTransactionWorker<Provider<A
 
                     for( ASTMethod astMethod : astType.getMethods()) {
                         annotations.addAll(astMethod.getAnnotations());
+
+                        for( ASTParameter astParameter : astMethod.getParameters()) {
+                            annotations.addAll(astParameter.getAnnotations());
+                        }
                     }
 
                     for( ASTField astField : astType.getFields()) {


### PR DESCRIPTION
...r field annotations of the specified type.  Previously it just returned class annotations.

This might not be the right solution in the long term, it might make more sense to keep one method with the original behavior and a second method with the new behavior.
